### PR TITLE
fix: building of the absolute URL

### DIFF
--- a/broken_link_checker/checker.py
+++ b/broken_link_checker/checker.py
@@ -191,6 +191,7 @@ class Checker:
                         if not url.startswith('#') and not url.startswith('?'):
                             # We build the absolute URL
                             url = urljoin(response._request_url, url)
+                            url = self.conn._absolute_url(url)
                         else:
                             # Since this URL is relative
                             # maybe it is not different of the parent


### PR DESCRIPTION
### WHAT
It's better to build absolute URL like "https://example.com/" instead of "/".

### NEW
We will got https://example.com/abc instead of /abc